### PR TITLE
Add simple declaration interface function

### DIFF
--- a/loco-core/src/main/java/com/sys1yagi/loco/core/Sender.kt
+++ b/loco-core/src/main/java/com/sys1yagi/loco/core/Sender.kt
@@ -3,6 +3,11 @@ package com.sys1yagi.loco.core
 import com.sys1yagi.loco.core.internal.SmashedLog
 
 interface Sender {
-
     suspend fun send(logs: List<SmashedLog>): SendingResult
+}
+
+fun Sender(send: (List<SmashedLog>) -> SendingResult) = object : Sender {
+    override suspend fun send(logs: List<SmashedLog>): SendingResult {
+        return send.invoke(logs)
+    }
 }

--- a/loco-core/src/main/java/com/sys1yagi/loco/core/Smasher.kt
+++ b/loco-core/src/main/java/com/sys1yagi/loco/core/Smasher.kt
@@ -6,3 +6,9 @@ package com.sys1yagi.loco.core
 interface Smasher {
     fun smash(log: LocoLog): String
 }
+
+fun Smasher(smash: (LocoLog) -> String) = object : Smasher {
+    override fun smash(log: LocoLog): String {
+        return smash.invoke(log)
+    }
+}


### PR DESCRIPTION
This PR is just a proposal. If it is not necessary, please feel free to close.

Add simple declaration interface function.
It allows us to declare `Smasher` and `Sender` like SAM conversion. It is convenient to declare simple sender and smasher like debugging purpose etc..

```kotlin
Loco.start(
    LocoConfig(
        ...
        smasher = Smasher {
            it.toString()
        },
        senders = listOf(
            Sender {
                it.forEach {
                    Log.d("LogcatSender", it.smashedLog)
                }
                return@Sender SendingResult.SUCCESS
            }
        ),
        ...
    )
)
```  